### PR TITLE
Normative: Add a new overload to make reuse easier.

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -158,6 +158,16 @@ test("Incompatible receiver", () => {
     y.next()
 })
 
+test("Argument 0 as options", () => {
+    const a = Number.range(0, 2)
+    const b = Number.range(a)
+    expect(a).toEqual(b)
+})
+
+test("Invalid 0 args", () => {
+    expect(() => Number.range({})).toThrow()
+})
+
 test("Inclusive on same start-end (issue #38)", () => {
     expect(that(Number.range(0, 0, { inclusive: true }))).toMatchInlineSnapshot(`"0f"`)
 })

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,6 +1,5 @@
 type Infinity = number
-interface RangeIterator<T extends number | bigint>
-    extends Iterator<T, void, void> {
+interface RangeIterator<T extends number | bigint> extends Iterator<T, void, void> {
     // This property is not in the spec yet.
     [Symbol.iterator](): RangeIterator<T>
     readonly [Symbol.toStringTag]: "RangeIterator"
@@ -10,11 +9,8 @@ interface RangeIterator<T extends number | bigint>
     readonly inclusive: boolean
 }
 type RangeFunction<T extends number | bigint> = {
-    range(
-        start: T,
-        end: T | Infinity,
-        option?: T | { step?: T; inclusive?: boolean }
-    ): RangeIterator<T>
+    range(option: { start: T; end: T | Infinity; step?: T; inclusive?: boolean }): RangeIterator<T>
+    range(start: T, end: T | Infinity, option?: T | { step?: T; inclusive?: boolean }): RangeIterator<T>
     range(start: T, end: T | Infinity, step?: T): RangeIterator<T>
 }
 interface NumberConstructor extends RangeFunction<number> {}

--- a/spec.emu
+++ b/spec.emu
@@ -30,30 +30,46 @@ contributors: "Jack Works"
 <emu-clause id="sec-algor">
     <h1>Algorithms</h1>
     <emu-clause id="sec-create-numeric-range-iterator">
-        <h1><dfn>CreateNumericRangeIterator</dfn>(_start_, _end_, _option_, _type_)</h1>
+        <h1><dfn>CreateNumericRangeIterator</dfn>(_arg0_, _arg1_, _arg2_, _type_)</h1>
         <emu-alg>
-            1. If Type(_start_) is not _type_, throw a *TypeError* exception.
             1. Assert: _type_ is *"number"* or *"bigint"*.
             1. If _type_ is *"bigint"*, let _zero_ be *0n*, else let _zero_ be *0*.
             1. If _type_ is *"bigint"*, let _one_ be *1n*, else let _one_ be *1*.
+            <!-- prepare -->
+            1. Let _option_ be *undefined*.
+            1. Let _start_ be *undefined*.
+            1. Let _end_ be *undefined*.
+            1. Let _step_ be *undefined*.
+            1. Let _inclusiveEnd_ be *false*.
+            1. If Type(_arg0_) is *"object"*,
+                1. Set _start_ to Get(_arg0_, "start").
+                1. Set _end_ to Get(_arg0_, "end").
+                1. Set _option_ to _arg0_.
+            1. Else if Type(_arg0_) is _type_,
+                1. Set _start_ to _arg0_.
+                1. Set _end_ to _arg1_.
+                1. Set _option_ to _arg2_.
+            1. Else, throw a *TypeError* exception.
+            1. If Type(_option_) is *object*,
+                1. Set _step_ to Get(_option_, "step").
+                1. Let _rawInclusiveEnd_ to Get(_option_, "inclusive").
+                1. If _rawInclusiveEnd_ is not *null* or *undefined*, Set _inclusiveEnd_ to ToBoolean(_rawInclusiveEnd_).
+            1. Else if Type(_option_) is _type_,
+                1. Set _step_ to _option_.
+            1. Else,
+                1. If _option_ is not *undefined* or *null, throw a *TypeError* exception.
+            <!-- normalize options ends -->
+            1. If Type(_start_) is not _type_, throw a *TypeError* exception.
+            1. If _start_ is *+∞* or *-∞*, throw a *RangeError* exception.
             1. Note: <emu-note type="editor">Allowing all kinds of number (number, bigint, decimals, ...) to range from a finite number to infinity.</emu-note>
             1. If _end_ is not *+∞* or *-∞* and if Type(_end_) is not _type_, throw a *TypeError* exception.
-            1. If _start_ is *+∞* or *-∞*, throws a *RangeError* exception.
-            1. Let _ifIncrease_ be end > start.
-            1. Let _inclusiveEnd_ be *false*.
-            <!-- Normalize options -->
-            1. If _option_ is *undefined* or *null*, let _step_ be *undefined*.
-            1. Else if Type(_option_) is *object*,
-                1. Let _step_ be Get(_option_, "step").
-                1. Let _inclusiveEnd_ be ToBoolean(Get(_option_, "inclusive")).
-            1. Else if Type(_option_) is _type_, let _step_ be _option_.
-            1. Else, throw a *TypeError* exception.
-            <!-- Normalize options end -->
-            1. If _step_ is *undefined* or *null*,
-                1. If _ifIncrease_ is *true*, let _step_ be _one_.
-                1. Else let _step_ be -_one_.
-            1. If Type(_step_) is not _type_, throws a *TypeError* exception.
             1. If _step_ is *+∞* or *-∞*, throws a *RangeError* exception.
+            1. Let _ifIncrease_ be _end_ > _start_.
+            1. Note: <emu-note type="editor">Null step might comes from the options.</emu-note>
+            1. If _step_ is *undefined* or *null*,
+                1. If _ifIncrease_ is *true*, Set _step_ to _one_.
+                1. Else, Set _step_ to -_one_.
+            1. If Type(_step_) is not _type_, throw a *TypeError* exception.
             1. If _step_ is _zero_ and _start_ is not equal to _end_, throws an *RangeError* exception.
             1. Let _closure_ be a new Abstract Closure with no parameters that captures _start_, _end_, _step_, _type_, _inclusiveEnd_, _zero_, _one_ and performs the following steps when called:
                 <!-- Early return -->


### PR DESCRIPTION
A new overload:

```diff
 type RangeFunction<T extends number | bigint> = {
+    range(option: { start: T; end: T | Infinity; step?: T; inclusive?: boolean }): RangeIterator<T>
     range(start: T, end: T | Infinity, option?: T | { step?: T; inclusive?: boolean }): RangeIterator<T>
     range(start: T, end: T | Infinity, step?: T): RangeIterator<T>
 }
```

This will allow the following pattern to make the reuse easier:

```js
const x = Number.range(0, 2)
consume_iterator(x)
const y = Number.range(x) // a fresh iterator
```